### PR TITLE
fix(deps): patch tar GHSA-qffp-2rhf-9h96 (hardlink path traversal)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12686,9 +12686,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
+      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   },
   "license": "MIT",
   "overrides": {
-    "js-yaml": "4.1.1"
+    "js-yaml": "4.1.1",
+    "tar": "7.5.10"
   },
   "dependencies": {
     "@cycjimmy/jsmpeg-player": "^6.1.2",


### PR DESCRIPTION
## Summary

- Adds `tar@7.5.10` to npm `overrides` to force the patched version across the dependency tree
- Transitive path: `electron-builder > app-builder-lib > tar`
- Resolves Dependabot alert #49 on main

**Advisory**: [GHSA-qffp-2rhf-9h96](https://github.com/advisories/GHSA-qffp-2rhf-9h96) — Hardlink Path Traversal via Drive-Relative Linkpath (high severity, `<=7.5.9`, fixed in `>=7.5.10`)

## Test plan

- [x] `npm install` — `found 0 vulnerabilities`
- [x] `npm audit` — clean
- [ ] Verify Dependabot alert closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)