### PR TITLE
feat(ui): add Edit Layout menu item + rename LegacyUiController to ShellController

### DIFF
--- a/ai_docs/UI_COMPONENTS.md
+++ b/ai_docs/UI_COMPONENTS.md
@@ -56,7 +56,7 @@ The settings dialog uses a modular, section-based architecture for improved main
 1. CSS & Icon Loading (Lucide icons)
 2. Debug State Initialization (initializeDebugState)
 3. Platform Detection & Theme Application
-4. Legacy UI Controller Setup (LegacyUiController)
+4. Shell Controller Setup (ShellController)
 5. Shortcut System Initialization
 6. Placeholder UI Setup
 7. Polling Listeners (polling-update IPC)
@@ -67,7 +67,7 @@ The settings dialog uses a modular, section-based architecture for improved main
 
 **Key Controllers**:
 - `RendererGridController`: Manages GridStack integration and component lifecycle
-- `LegacyUiController`: Handles legacy UI updates and compatibility
+- `ShellController`: Owns the window chrome — window controls, hamburger menu (incl. Edit Layout), and loading overlay
 - `ShortcutButtonController`: Manages top-bar shortcuts and dialog wiring
 
 **Per-Printer State Tracking**:
@@ -241,7 +241,7 @@ Polling updates forwarded
 - `src/renderer/src/renderer.ts`, `src/renderer/src/gridController.ts`, `src/renderer/src/shortcutButtons.ts`, `src/renderer/src/perPrinterStorage.ts`, `src/renderer/src/logging.ts`
 - `src/renderer/src/ui/components/**` (ComponentManager, printer tabs, job info, etc.) + `src/renderer/src/ui/gridstack/**` for layout/palette logic
 - `src/renderer/src/ui/component-dialog/**` – component dialog renderer + preload mirrors
-- `src/renderer/src/ui/legacy/LegacyUiController.ts` – legacy UI compatibility layer
+- `src/renderer/src/ui/shell/ShellController.ts` – window chrome (controls, menu, loading overlay)
 
 **GridStack System**
 - `src/renderer/src/ui/gridstack/GridStackManager.ts` – grid initialization and widget management

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -68,7 +68,7 @@
           <span class="menu-item-shortcut" data-shortcut-id="pin-config">Ctrl+P</span>
         </button>
 
-        <button class="menu-item" data-action="edit-layout" role="menuitem" aria-keyshortcuts="Control+E">
+        <button class="menu-item" data-action="edit-layout" role="menuitemcheckbox" aria-checked="false" aria-keyshortcuts="Control+E">
           <span class="menu-item-content">
             <i data-lucide="pencil" class="menu-item-icon" aria-hidden="true"></i>
             <span class="menu-item-label">Edit Layout</span>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -68,6 +68,14 @@
           <span class="menu-item-shortcut" data-shortcut-id="pin-config">Ctrl+P</span>
         </button>
 
+        <button class="menu-item" data-action="edit-layout" role="menuitem" aria-keyshortcuts="Control+E">
+          <span class="menu-item-content">
+            <i data-lucide="pencil" class="menu-item-icon" aria-hidden="true"></i>
+            <span class="menu-item-label">Edit Layout</span>
+          </span>
+          <span class="menu-item-shortcut" data-shortcut-id="edit-layout">Ctrl+E</span>
+        </button>
+
         <div class="menu-divider" role="presentation"></div>
 
         <button class="menu-item" data-action="about" role="menuitem">

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -305,6 +305,16 @@ body {
   display: none;
 }
 
+.menu-item:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.menu-item:disabled:hover {
+  background-color: transparent;
+  transform: none;
+}
+
 .menu-item-content {
   display: inline-flex;
   align-items: center;

--- a/src/renderer/src/renderer.ts
+++ b/src/renderer/src/renderer.ts
@@ -48,7 +48,7 @@ import { editModeController } from './ui/gridstack/EditModeController.js';
 // GridStack system imports
 import { gridStackManager } from './ui/gridstack/GridStackManager.js';
 import { layoutPersistence } from './ui/gridstack/LayoutPersistence.js';
-import { LegacyUiController } from './ui/legacy/LegacyUiController.js';
+import { ShellController } from './ui/shell/ShellController.js';
 // Shortcut system imports
 import { DEFAULT_SHORTCUT_CONFIG } from './ui/shortcuts/types.js';
 
@@ -116,7 +116,7 @@ const shortcutButtonController = new ShortcutButtonController({
   gridController,
 });
 
-const legacyUiController = new LegacyUiController(logMessage, () => editModeController.toggle());
+const shellController = new ShellController(logMessage, () => editModeController.toggle());
 const RENDERER_LOG_NAMESPACE = 'Renderer';
 const logDebug = (message: string, ...args: unknown[]): void => {
   logVerbose(RENDERER_LOG_NAMESPACE, message, ...args);
@@ -401,9 +401,8 @@ function initializePollingListeners(): void {
           console.error('Component system update failed:', error);
           logMessage(`ERROR: Component update failed: ${error}`);
 
-          // Fallback to legacy update system if components fail
-          console.warn('Falling back to legacy UI update system');
-          // Note: updateAllPanels is removed, so we'll handle this gracefully
+          // The component system is the only renderer for printer data; there is
+          // no fallback path, so surface the failure gracefully.
           handleUIError(error, 'component system failure');
         }
       }
@@ -632,12 +631,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   logDebug('IPC listeners configured for component system integration');
 
   // Setup essential UI elements
-  legacyUiController.initialize();
+  shellController.initialize();
 
   // Keep the "Edit Layout" menu item in sync with edit mode state, regardless
   // of how it was toggled (menu, CTRL+E, layout reset, or printer disconnect).
   editModeController.onStateChange(({ enabled, available }) => {
-    legacyUiController.setEditModeState(enabled, available);
+    shellController.setEditModeState(enabled, available);
   });
 
   // Initialize shortcut button system
@@ -683,7 +682,7 @@ document.addEventListener('DOMContentLoaded', async () => {
  */
 window.addEventListener('beforeunload', () => {
   logDebug('Cleaning up resources in enhanced renderer with GridStack and component system');
-  legacyUiController.dispose();
+  shellController.dispose();
 
   // Clean up GridStack system
   try {

--- a/src/renderer/src/renderer.ts
+++ b/src/renderer/src/renderer.ts
@@ -116,7 +116,7 @@ const shortcutButtonController = new ShortcutButtonController({
   gridController,
 });
 
-const legacyUiController = new LegacyUiController(logMessage);
+const legacyUiController = new LegacyUiController(logMessage, () => editModeController.toggle());
 const RENDERER_LOG_NAMESPACE = 'Renderer';
 const logDebug = (message: string, ...args: unknown[]): void => {
   logVerbose(RENDERER_LOG_NAMESPACE, message, ...args);
@@ -633,6 +633,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Setup essential UI elements
   legacyUiController.initialize();
+
+  // Keep the "Edit Layout" menu item in sync with edit mode state, regardless
+  // of how it was toggled (menu, CTRL+E, layout reset, or printer disconnect).
+  editModeController.onStateChange(({ enabled, available }) => {
+    legacyUiController.setEditModeState(enabled, available);
+  });
 
   // Initialize shortcut button system
   shortcutButtonController.initialize();

--- a/src/renderer/src/ui/gridstack/EditModeController.ts
+++ b/src/renderer/src/ui/gridstack/EditModeController.ts
@@ -90,6 +90,38 @@ export class EditModeController {
   /** Whether controller is initialized */
   private initialized = false;
 
+  /** Subscribers notified when edit mode enabled/availability changes */
+  private readonly stateChangeListeners: Array<(state: { enabled: boolean; available: boolean }) => void> = [];
+
+  /**
+   * Subscribe to edit mode state changes (enabled + availability).
+   * The listener is invoked immediately with the current state so callers
+   * can synchronize their UI without duplicating the initial read.
+   * @param listener - Callback invoked on every state change
+   * @returns Disposer that removes the listener
+   */
+  onStateChange(listener: (state: { enabled: boolean; available: boolean }) => void): () => void {
+    this.stateChangeListeners.push(listener);
+    listener({ enabled: this.state.enabled, available: this.editingAvailable });
+
+    return () => {
+      const index = this.stateChangeListeners.indexOf(listener);
+      if (index !== -1) {
+        this.stateChangeListeners.splice(index, 1);
+      }
+    };
+  }
+
+  /**
+   * Notify all subscribers of the current edit mode state
+   */
+  private emitStateChange(): void {
+    const snapshot = { enabled: this.state.enabled, available: this.editingAvailable };
+    for (const listener of this.stateChangeListeners) {
+      listener(snapshot);
+    }
+  }
+
   /**
    * Initialize the edit mode controller
    * @param gridManager - GridStack manager instance
@@ -258,6 +290,8 @@ export class EditModeController {
         console.warn('EditModeController: API not available to open palette');
       }
 
+      this.emitStateChange();
+
       console.log('EditModeController: Edit mode enabled');
     } catch (error) {
       console.error('EditModeController: Failed to enter edit mode:', error);
@@ -310,6 +344,8 @@ export class EditModeController {
       } else {
         console.warn('EditModeController: API not available to close palette');
       }
+
+      this.emitStateChange();
 
       console.log('EditModeController: Edit mode disabled');
     } catch (error) {
@@ -458,9 +494,15 @@ export class EditModeController {
    * Set whether edit mode can be enabled (based on printer availability)
    */
   setAvailability(available: boolean): void {
+    const changed = this.editingAvailable !== available;
     this.editingAvailable = available;
     if (!available && this.state.enabled) {
+      // exitEditMode emits its own state change with the updated availability
       this.exitEditMode();
+      return;
+    }
+    if (changed) {
+      this.emitStateChange();
     }
   }
 

--- a/src/renderer/src/ui/gridstack/EditModeController.ts
+++ b/src/renderer/src/ui/gridstack/EditModeController.ts
@@ -117,7 +117,8 @@ export class EditModeController {
    */
   private emitStateChange(): void {
     const snapshot = { enabled: this.state.enabled, available: this.editingAvailable };
-    for (const listener of this.stateChangeListeners) {
+    // Iterate a copy so listeners that unsubscribe during the callback are not skipped.
+    for (const listener of [...this.stateChangeListeners]) {
       listener(snapshot);
     }
   }

--- a/src/renderer/src/ui/legacy/LegacyUiController.ts
+++ b/src/renderer/src/ui/legacy/LegacyUiController.ts
@@ -211,8 +211,33 @@ export class LegacyUiController {
   private readonly menuShortcutManager: MenuShortcutManager;
   private currentLoadingState: LoadingState = { ...defaultLoadingState };
 
-  constructor(private readonly logMessage: (message: string) => void) {
+  constructor(
+    private readonly logMessage: (message: string) => void,
+    private readonly onEditLayout?: () => void
+  ) {
     this.menuShortcutManager = new MenuShortcutManager(() => this.closeMainMenu());
+  }
+
+  /**
+   * Update the "Edit Layout" menu item to reflect the current edit mode state.
+   * Edit mode is renderer-local (driven by EditModeController), so this is
+   * called from a state-change subscription rather than via IPC.
+   * @param enabled - Whether edit mode is currently active
+   * @param available - Whether edit mode can be toggled (requires an active printer)
+   */
+  setEditModeState(enabled: boolean, available: boolean): void {
+    const button = document.querySelector<HTMLButtonElement>('.menu-item[data-action="edit-layout"]');
+    if (!button) {
+      return;
+    }
+
+    const label = button.querySelector<HTMLSpanElement>('.menu-item-label');
+    if (label) {
+      label.textContent = enabled ? 'Exit Edit Mode' : 'Edit Layout';
+    }
+
+    button.disabled = !available;
+    button.setAttribute('aria-pressed', enabled ? 'true' : 'false');
   }
 
   initialize(): void {
@@ -373,10 +398,20 @@ export class LegacyUiController {
       this.toggleMainMenu();
     });
 
+    this.applyEditLayoutShortcutLabel();
+
     const menuItems = this.mainMenuDropdown.querySelectorAll<HTMLButtonElement>('.menu-item');
     menuItems.forEach((item) => {
       item.addEventListener('click', () => {
         const action = item.getAttribute('data-action');
+
+        // Edit mode is a renderer-local toggle (EditModeController), not an IPC action.
+        if (action === 'edit-layout') {
+          this.onEditLayout?.();
+          this.closeMainMenu();
+          return;
+        }
+
         const channel = MAIN_MENU_ACTION_CHANNELS[action as MainMenuAction];
         if (channel && window.api?.send) {
           window.api.send(channel);
@@ -407,6 +442,26 @@ export class LegacyUiController {
         this.mainMenuButton?.focus();
       }
     });
+  }
+
+  /**
+   * Set the edit-layout shortcut hint label for the current platform.
+   * This item is handled by EditModeController (not MenuShortcutManager),
+   * so its hint must be localized here rather than via the shortcut manager.
+   */
+  private applyEditLayoutShortcutLabel(): void {
+    const shortcutEl = document.querySelector<HTMLSpanElement>(
+      '.menu-item-shortcut[data-shortcut-id="edit-layout"]'
+    );
+    if (!shortcutEl) {
+      return;
+    }
+
+    const isMac = window.PLATFORM === 'darwin';
+    shortcutEl.textContent = isMac ? '⌘E' : 'Ctrl+E';
+
+    const button = shortcutEl.closest<HTMLButtonElement>('.menu-item[data-action="edit-layout"]');
+    button?.setAttribute('aria-keyshortcuts', isMac ? 'Meta+E' : 'Control+E');
   }
 
   private closeMainMenu(): void {

--- a/src/renderer/src/ui/shell/ShellController.ts
+++ b/src/renderer/src/ui/shell/ShellController.ts
@@ -241,7 +241,7 @@ export class ShellController {
     }
 
     button.disabled = !available;
-    button.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+    button.setAttribute('aria-checked', enabled ? 'true' : 'false');
   }
 
   initialize(): void {

--- a/src/renderer/src/ui/shell/ShellController.ts
+++ b/src/renderer/src/ui/shell/ShellController.ts
@@ -1,10 +1,14 @@
 /**
- * @fileoverview Shell UI controller for renderer chrome and legacy menus.
+ * @fileoverview Shell controller for the renderer's window chrome.
  *
- * Manages window controls, hamburger menu (including keyboard shortcuts),
- * and the loading overlay that predates the component/GridStack system.
- * All printer-specific controls now live in dedicated components, so this
- * controller only keeps the shared chrome responsibilities.
+ * Owns the shared chrome that frames the dashboard: window controls
+ * (minimize/maximize/close + macOS traffic lights), the hamburger menu and
+ * its keyboard shortcuts, the "Edit Layout" toggle, and the loading overlay.
+ * Printer-specific controls live in dedicated components/GridStack widgets;
+ * this controller intentionally holds only the cross-cutting chrome.
+ *
+ * Key exports:
+ * - ShellController: Initializes and manages the renderer chrome
  */
 
 import { initializeUIAnimations } from '../../renderer/services/ui-updater.js';
@@ -203,7 +207,7 @@ class MenuShortcutManager {
   }
 }
 
-export class LegacyUiController {
+export class ShellController {
   private isMainMenuOpen = false;
   private mainMenuButton: HTMLButtonElement | null = null;
   private mainMenuDropdown: HTMLDivElement | null = null;


### PR DESCRIPTION
## Summary

Closes the edit-mode discoverability gap from #62 and cleans up a misleading class name. Two split commits:

1. **`feat(ui)`: Edit Layout menu item** — adds a visible entry point to GridStack edit mode in the hamburger menu, since it was previously reachable only via the undocumented CTRL+E shortcut (the WebUI already had a visible toggle).
2. **`refactor(ui)`: rename `LegacyUiController` → `ShellController`** — the old name implied dead code / a tie to legacy *printers*; it's actually the active window chrome.

## Issue #62 context

The reporter (Windows 11, 3440×1440) saw widgets not filling vertical space when maximized. It turned out **not to be a bug** — they fixed it themselves using edit mode once pointed to it, then asked: *"May I suggest adding a button/menu item for the edit mode?"* This PR does exactly that.

## Feature details

- New `Edit Layout` menu item (pencil icon) with a platform-aware `Ctrl+E` / `⌘E` hint.
- **Dynamic label** flips between "Edit Layout" and "Exit Edit Mode".
- **Disabled when no printer is connected**, matching existing `editModeController.setAvailability` behavior.
- `EditModeController` gains an `onStateChange` subscription so the label stays in sync no matter how edit mode is toggled (menu, CTRL+E, layout reset, or printer disconnect).
- Edit mode is renderer-local, so the item invokes `editModeController.toggle()` directly rather than sending IPC like the other menu items.

## Refactor details

- Moved `src/renderer/src/ui/legacy/LegacyUiController.ts` → `src/renderer/src/ui/shell/ShellController.ts` (git rename, 96% similarity).
- Rewrote the `@fileoverview` to describe it accurately as window chrome.
- Updated references in `renderer.ts` and `ai_docs/UI_COMPONENTS.md`.
- Removed a stale "fallback to legacy update system" comment referencing the already-removed `updateAllPanels` path.
- **No behavior change.** "Legacy printer" terminology (Adventurer 3/4) is intentionally left intact as a legitimate domain term.

## Validation

- `pnpm type-check` ✓
- `pnpm lint` ✓ (376 files, no issues)
- `pnpm build` ✓ (main + renderer compile)
- Each commit builds independently.

## Notes

Manual UI verification (clicking the item, label toggling, disabled-when-disconnected) has not been done in a running app yet — reviewer or author may want to smoke-test before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
